### PR TITLE
Do not include passwords for OPEN networks

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -107,11 +107,12 @@ var configure = function(evt){
   var jsonData = {
     idx:0,
     ssid: network.ssid,
-    pwd: rsa.encrypt(password),
     sec: network.sec,
     ch: network.ch
-
-  };
+  }; 
+  if(network.sec != 0){
+	  jsonData.pwd = rsa.encrypt(password);
+  }
   // send
   connectButton.innerHTML = 'Sending credentials...';
   disableButtons();


### PR DESCRIPTION
OPEN networks join requests should not include the "pwd" param